### PR TITLE
Fix video collection with await video.path()

### DIFF
--- a/src/pytest_playwright_async/__init__.py
+++ b/src/pytest_playwright_async/__init__.py
@@ -152,7 +152,7 @@ async def context_async(
             if not video:
                 continue
             try:
-                video_path = video.path()
+                video_path = await video.path()
                 file_name = os.path.basename(video_path)
                 await video.save_as(
                     path=_build_artifact_test_folder(pytestconfig, request, file_name)


### PR DESCRIPTION
Fix for https://github.com/m9810223/playwright-async-pytest/issues/5 in upstream repo, fixes issue when collecting test video (without await, video.path() returns coroutine, causes issue in finalizer